### PR TITLE
Support bumping IDs with randomly chosen lock_for

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+v0.4.3 2015-06-02 -- Support bumping IDs with randomly chosen lock_for
+
 v0.4.2 2013-02-24 -- Issue START TRANSACTION for every operation
 
 v0.4.1, 2012-08-07 -- Just use transactions for read-only operations


### PR DESCRIPTION
doloop.bump's lock_for kwarg can now take a 2-tuple of the form (min_lock_for, max_lock_for), in which case each bumped ID will be randomly assigned a lock_for N such that min_lock_for <= N < max_lock_for.

This is useful because it allows IDs to be fetched randomly w.r.t. the order in which they were inserted. There is a performance benefit to bumping a set of IDs in a single call to doloop.bump instead of one call per ID (1 vs many mysql update statements issued).